### PR TITLE
alreemt - refactor(posts): clean up redirectToPost, moved stuff into helpers

### DIFF
--- a/src/controllers/posts.js
+++ b/src/controllers/posts.js
@@ -14,53 +14,65 @@ const helpers = require('./helpers');
 const postsController = module.exports;
 
 postsController.redirectToPost = async function (req, res, next) {
-  const pid = parsePid(req.params.pid);
-  if (!pid) return next();
+	const pid = parsePid(req.params.pid);
+	if (!pid) return next();
 
-  await maybeAssertActivityPubNote(pid, req.uid);
+	await maybeAssertActivityPubNote(pid, req.uid);
 
-  const { canRead, path } = await fetchAccessAndPath(pid, req.uid);
-  if (!path) return next();
-  if (!canRead) return helpers.notAllowed(req, res);
+	const { canRead, path } = await fetchAccessAndPath(pid, req.uid);
+	if (!path) return next();
+	if (!canRead) return helpers.notAllowed(req, res);
 
-  setActivityPubLinkHeaderIfEnabled(res, req.params.pid);
-  return helpers.redirect(res, buildUrlWithQuery(path, req.query), true);
+	setActivityPubLinkHeaderIfEnabled(res, req.params.pid);
+
+	const url = buildUrlWithQuery(path, req.query);
+	return helpers.redirect(res, url, true);
 };
 
-// --- Local helpers ---
+
+postsController.getRecentPosts = async function (req, res) {
+	const page = parseInt(req.query.page, 10) || 1;
+	const postsPerPage = 20;
+	const start = Math.max(0, (page - 1) * postsPerPage);
+	const stop = start + postsPerPage - 1;
+	const data = await posts.getRecentPosts(req.uid, start, stop, req.params.term);
+	res.json(data);
+};
+
+// --- Local helpers (no behavior change) ---
 
 function parsePid(raw) {
-  return utils.isNumber(raw) ? parseInt(raw, 10) : raw;
+	return utils.isNumber(raw) ? parseInt(raw, 10) : raw;
 }
 
 async function maybeAssertActivityPubNote(pid, uid) {
-  if (!utils.isNumber(pid) && uid && meta.config.activitypubEnabled) {
-    const exists = await posts.exists(pid);
-    if (!exists) {
-      await activitypub.notes.assert(uid, pid);
-    }
-  }
+	// Kickstart note assertion if applicable
+	if (!utils.isNumber(pid) && uid && meta.config.activitypubEnabled) {
+		const exists = await posts.exists(pid);
+		if (!exists) {
+			await activitypub.notes.assert(uid, pid);
+		}
+	}
 }
 
 async function fetchAccessAndPath(pid, uid) {
-  const [canRead, path] = await Promise.all([
-    privileges.posts.can('topics:read', pid, uid),
-    posts.generatePostPath(pid, uid),
-  ]);
-  return { canRead, path };
+	const [canRead, path] = await Promise.all([
+		privileges.posts.can('topics:read', pid, uid),
+		posts.generatePostPath(pid, uid),
+	]);
+	return { canRead, path };
 }
 
 function setActivityPubLinkHeaderIfEnabled(res, routePid) {
-  if (meta.config.activitypubEnabled) {
-    res.set(
-      'Link',
-      `<${nconf.get('url')}/post/${routePid}>; rel="alternate"; type="application/activity+json"`
-    );
-  }
+	if (meta.config.activitypubEnabled) {
+		res.set(
+			'Link',
+			`<${nconf.get('url')}/post/${routePid}>; rel="alternate"; type="application/activity+json"`
+		);
+	}
 }
 
 function buildUrlWithQuery(path, query) {
-  const qs = querystring.stringify(query);
-  return qs ? `${path}?${qs}` : path;
+	const qs = querystring.stringify(query);
+	return qs ? `${path}?${qs}` : path;
 }
-


### PR DESCRIPTION
made redirecttopost shorter and easier to follow by moving some steps into small helper functions. works the same, just cleaner.